### PR TITLE
parseDateString returns null on invalid datestring rather than throwing an exception

### DIFF
--- a/src/angular-input-date.js
+++ b/src/angular-input-date.js
@@ -9,6 +9,8 @@
      * @returns {Date|null}
      */
     function parseDateString(dateString) {
+        if(typeof dateString === 'undefined'){return null;}
+        
         var parts = dateString.split('-');
         if (3 !== parts.length) {
             return null;


### PR DESCRIPTION
Ran into a few cases where the parseDate function would get an 'undefined' and throw an exception on the `split`. This happens in some cases from user error, but also when I try to do things such as set the input value to blank to force a dirty flag. It'd be nice if it just became invalid in the case of a invalid value rather than raising a browser exception.
